### PR TITLE
Register z3c.autoinclude entry point for automatic inclusion in plone.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 0.16 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Register ``z3c.autoinclude`` entry point for automatic inclusion in plone.  [maurits]
 
 
 0.15 (2017-08-09)

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,6 @@ setup(
     ],
     entry_points='''
         [z3c.autoinclude.plugin]
-        target = z3c.form
+        target = plone
     ''',
 )


### PR DESCRIPTION
Version 0.15 of last week introduced z3c.autoinclude with a target of `z3c.form`, but `z3c.form` does not do anything with it.  So use the `plone` target instead. This means the translations gets picked up automatically in Plone.