### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-2.2 (unreleased)
+3.0 (unreleased)
 ----------------
 
 - Nothing changed yet.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 3.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 2.1 (2025-04-08)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!python
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -17,17 +16,14 @@ setup(
     keywords="zope zope3 z3c.form",
     url='https://github.com/zopefoundation/z3c.formwidget.query',
     zip_safe=False,
-    packages=find_packages('src'),
     include_package_data=True,
-    package_dir={'': 'src'},
-    namespace_packages=['z3c', 'z3c.formwidget'],
     python_requires='>=3.9',
     extras_require=dict(
         test=[
             'lxml',
             'z3c.form [test]',
             'zope.testing',
-            'zope.testrunner',
+            'zope.testrunner >= 6.4',
         ]),
     install_requires=[
         'setuptools',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='z3c.formwidget.query',
-    version='2.2.dev0',
+    version='3.0.dev0',
     author="Zope Community",
     author_email="zope-dev@zope.dev",
     description="A source query widget for z3c.form.",

--- a/src/z3c/__init__.py
+++ b/src/z3c/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover

--- a/src/z3c/formwidget/__init__.py
+++ b/src/z3c/formwidget/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
